### PR TITLE
fix building of test program at link stage

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -21,12 +21,12 @@
  
 #include "main.h"
 
-global_struct g;
+extern global_struct g;
 #ifdef HAVE_HDF5
 Hdf5_fileinfo h5info;
 #endif
-struct common_thread_data *commonthreaddata;
-struct Thread *no_threading;
+extern struct common_thread_data *commonthreaddata;
+extern struct Thread *no_threading;
 
 int main( int argc, char **argv ) {
     


### PR DESCRIPTION
building of `main.o` fails due to missing external linkage declaration for a number of global structs

```
/usr/bin/ld: build/main.o:(.bss+0x8): multiple definition of `commonthreaddata'; build/DDalphaAMG_interface.o:(.bss+0x10): first defined here
/usr/bin/ld: build/main.o:(.bss+0x0): multiple definition of `no_threading'; build/DDalphaAMG_interface.o:(.bss+0x0): first defined here
/usr/bin/ld: build/main.o:(.bss+0x20): multiple definition of `g'; build/DDalphaAMG_interface.o:(.bss+0x20): first defined here
```